### PR TITLE
Only consider objects for serialization

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -1,10 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should not serialize array 1`] = `
+Array [
+  true,
+  "a",
+  1,
+  Object {
+    "foo": "bar",
+  },
+  null,
+  undefined,
+]
+`;
+
 exports[`should not serialize non-HTTP response 1`] = `
 Object {
   "foo": "bar",
+  "null": null,
+  "undefined": undefined,
 }
 `;
+
+exports[`should not serialize null 1`] = `null`;
+
+exports[`should not serialize undefined 1`] = `undefined`;
 
 exports[`should serialize HTTP Buffer response 1`] = `
 {

--- a/index.js
+++ b/index.js
@@ -3,13 +3,12 @@
 const sortKeys = require('sort-keys')
 const toSchema = require('generate-schema').json
 
-const isObject = res => typeof res === 'object' && !!res
 const isSupertest = res => res.status && res.body
 const isLightMyRequest = res => res.statusCode && res.body
 
 const JSONRestAPISnapshotSerializer = {
   test: (res) =>
-    isObject(res) && [
+    res && [
       isSupertest,
       isLightMyRequest
     ].some(testFn => testFn(res)),

--- a/index.js
+++ b/index.js
@@ -3,14 +3,16 @@
 const sortKeys = require('sort-keys')
 const toSchema = require('generate-schema').json
 
+const isObject = res => typeof res === 'object' && !!res
 const isSupertest = res => res.status && res.body
 const isLightMyRequest = res => res.statusCode && res.body
 
 const JSONRestAPISnapshotSerializer = {
-  test: (res) => [
-    isSupertest,
-    isLightMyRequest
-  ].some(testFn => testFn(res)),
+  test: (res) =>
+    isObject(res) && [
+      isSupertest,
+      isLightMyRequest
+    ].some(testFn => testFn(res)),
   print: ({ body }) => {
     const contents = tryParse(body)
     const schema = sortKeys(toSchema(contents), { deep: true })

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ const serializer = require('./')
 expect.addSnapshotSerializer(serializer)
 
 test('should not serialize non-HTTP response', () => {
-  const object = { foo: 'bar' }
+  const object = { foo: 'bar', null: null, undefined: undefined }
   expect(object).toMatchSnapshot()
 })
 
@@ -22,4 +22,16 @@ test('should serialize HTTP Buffer response', () => {
 test('should serialize LightMyRequest HTTP response', () => {
   const object = { statusCode: 200, body: '{ "Hello": "World" }' }
   expect(object).toMatchSnapshot()
+})
+
+test('should not serialize null', () => {
+  expect(null).toMatchSnapshot()
+})
+
+test('should not serialize undefined', () => {
+  expect(undefined).toMatchSnapshot()
+})
+
+test('should not serialize array', () => {
+  expect([true, 'a', 1, { foo: 'bar' }, null, undefined]).toMatchSnapshot()
 })


### PR DESCRIPTION
Nice serializer, but it fails when matching snapshots on null and undefined (even when they are values futher down in an object structure).
I changed so that only objects should be considered for serialization and updated the tests.